### PR TITLE
move varnish_purge to failing, remove patches that can't be applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -371,9 +371,6 @@
             "drupal/cloudflare": {
                 "Cloudflarepurge: Allow for altering targets before purging": "https://www.drupal.org/files/issues/2019-04-01/3044887-n2.patch"
             },
-            "drupal/components": {
-                "Drupal 9 Deprecated Code Report for Components module": "https://www.drupal.org/files/issues/2020-03-13/components-twig-3112929-5.patch"
-            },
             "drupal/config_devel": {
                 "Deprecated Code Report": "https://www.drupal.org/files/issues/2019-11-14/deprecated-3094340-2.patch"
             },
@@ -381,14 +378,10 @@
                 "Fix test issues for 2.x version of module":"https://www.drupal.org/files/issues/2020-04-03/3124767-2.patch"
             },
             "drupal/context": {
-                "Drupal 9 Deprecated Code Report":"https://www.drupal.org/files/issues/2020-03-27/3042764-6.patch"
+                "Drupal 9 Deprecated Code Report":"https://www.drupal.org/files/issues/2020-05-25/remove_deprecated_code-3042764-11.patch"
             },
             "drupal/draggableviews": {
                 "Drupal 9 Deprecated Code Report": "https://www.drupal.org/files/issues/2020-01-03/draggableviews-3051083-7.patch"
-            },
-            "drupal/easy_install": {
-                "Compatibility with Drupal 9":"https://www.drupal.org/files/issues/2020-03-16/3120071-2.patch",
-                "Call to deprecated function file_scan_directory()":"https://www.drupal.org/files/issues/2020-03-16/3120075-2.patch"
             },
             "drupal/elasticsearch_connector": {
                 "Filters breaking score if no query string": "https://www.drupal.org/files/issues/2019-10-15/3087971-filters-breaking-score.patch",
@@ -456,19 +449,13 @@
                 "Replace deprecated method aliasManager() of class Drush\\Drush. (D9)": "https://www.drupal.org/files/issues/2019-10-12/1-purge-drupal9-replace-aliasmanager.patch"
             },
             "drupal/purge_queuer_url": {
-                "Logged-in requests remove items from traffic registry":"https://www.drupal.org/files/issues/2018-05-29/purge_queuer_url-2912139-7-skip-logged-in.patch",
-                "Command 'drush sql-sanitize' errors on uninstalled module": "https://www.drupal.org/files/issues/2950814-drush-sanitize-service-check.patch",
-                "Add Blacklisting of Cache Tags": "https://www.drupal.org/files/issues/2018-10-15/purge_queuer_url-2890476-8.patch",
-                "Deprecation issues": "https://www.drupal.org/files/issues/2019-11-15/purge_queuer_url-3094771-2.patch"
+                "Logged-in requests remove items from traffic registry":"https://www.drupal.org/files/issues/2018-05-29/purge_queuer_url-2912139-7-skip-logged-in.patch"
             },  
             "drupal/queue_ui": {
                 "Drupal 9 Compatibility": "https://www.drupal.org/files/issues/2020-02-04/3097065-11-drupal-9-compatibility.patch"
             },
             "drupal/quick_node_clone": {
                 "Deprecated Code Report": "https://www.drupal.org/files/issues/2020-03-20/3076998-20.patch"
-            },
-            "drupal/responsive_favicons": {
-                "D9 deprecation report": "https://www.drupal.org/files/issues/2019-11-21/d9-deprecation-fix-3094678-09.patch"
             },
             "drupal/search_exclude": {
                 "Drupal 9 Deprecated Method used": "https://www.drupal.org/files/issues/2019-08-20/se-3073740-6.patch"

--- a/scripts/test5.sh
+++ b/scripts/test5.sh
@@ -95,11 +95,6 @@ docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush en
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drupal-check modules/contrib/unlimited_number"
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush pm-uninstall unlimited_number -y"
 
-# Varnish Purge
-docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush en varnish_purger varnish_focal_point_purge varnish_image_purge varnish_purge_tags -y" && \
-docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drupal-check modules/contrib/varnish_purge" && \
-docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush pm-uninstall varnish_purger varnish_purge_tags varnish_image_purge varnish_focal_point_purge -y"
-
 # Video Embed Facebook
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush en video_embed_facebook -y" && \
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drupal-check modules/contrib/video_embed_facebook" && \

--- a/scripts/testsfail7.sh
+++ b/scripts/testsfail7.sh
@@ -103,6 +103,14 @@ docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drupal-c
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush pm-uninstall user_default_page -y"
 set -e -o pipefail
 
+
+# Varnish Purge
+set +e
+docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush en varnish_purger varnish_focal_point_purge varnish_image_purge varnish_purge_tags -y" && \
+docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drupal-check modules/contrib/varnish_purge" && \
+docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush pm-uninstall varnish_purger varnish_purge_tags varnish_image_purge varnish_focal_point_purge -y"
+set -e -o pipefail
+
 # Views Entity Operation Access (VEOA)
 set +e
 docker-compose exec php7.3 /bin/sh -c "cd /var/www/html/docroot; ../bin/drush en veoa -y"


### PR DESCRIPTION
- Moved `varnish_purge` to failing.

- Updated `context` patch to:             
    "drupal/context": {
        "Drupal 9 Deprecated Code Report":"https://www.drupal.org/files/issues/2020-05-25/remove_deprecated_code-3042764-11.patch"

- Removed `responsive_favicons` patch that was not applying. The issue has been labelled fixed:
    "drupal/responsive_favicons": {
        "D9 deprecation report": "https://www.drupal.org/files/issues/2020-04-28/d9-deprecation-report-3094678-1.patch"

- Removed `easy_install` patches that could not be applied because they had been committed to the repo:
    "drupal/easy_install": {
        "Call to deprecated function file_scan_directory()":"https://www.drupal.org/files/issues/2020-03-16/3120075-2.patch"

- Removed 3 of 4 patches on `purge_queuer_url`: 
    "drupal/purge_queuer_url": {       
        "Add Blacklisting of Cache Tags": "https://www.drupal.org/files/issues/2018-10-15/purge_queuer_url-2890476-8.patch"
        "Command 'drush sql-sanitize' errors on uninstalled module": "https://www.drupal.org/files/issues/2950814-drush-sanitize-service-check.patch",
        "Deprecation issues": "https://www.drupal.org/files/issues/2019-11-15/purge_queuer_url-3094771-2.patch"

- Removed `components` patch that had been committed to the repo:         
    "drupal/components": {
        "Drupal 9 Deprecated Code Report for Components module": "https://www.drupal.org/files/issues/2020-03-13/components-twig-3112929-5.patch"